### PR TITLE
Add GitHub workflow to build firmware

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,43 @@
+name: KungFuFlash2 Build
+
+on:
+  push:
+    branches:
+      - main
+      - master
+      - dev
+  pull_request:
+    branches:
+      - main
+      - master
+      - dev
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Set up ARM toolchain
+        run: |
+          sudo apt update
+          sudo apt install -y gcc-arm-none-eabi
+
+      - name: Install cc65
+        run: |
+          sudo apt install -y cc65
+
+      - name: Build Firmware
+        run: |
+          cd firmware
+          make
+
+      - name: Verify build success
+        run: |
+          if ! ls firmware/build/*.bin 1>/dev/null 2>&1; then
+            echo "Build failed: No .bin file found in the firmware/build/ folder!"
+            exit 1
+          fi
+          echo "Build successful!"
+


### PR DESCRIPTION
## Summary
- add CI workflow to compile Kung Fu Flash 2 firmware using arm-none-eabi-gcc and cc65

## Testing
- `make` *(fails: ca65 missing)*

------
https://chatgpt.com/codex/tasks/task_e_688cc171d798832392150005a4c33d9a