### PR TITLE
ci: upload firmware artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Upload firmware artifacts
         if: success()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: firmware-build
           path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,3 +41,12 @@ jobs:
           fi
           echo "Build successful!"
 
+      - name: Upload firmware artifacts
+        if: success()
+        uses: actions/upload-artifact@v3
+        with:
+          name: firmware-build
+          path: |
+            firmware/build/*.bin
+            firmware/build/*.upd
+


### PR DESCRIPTION
## Summary
- upload compiled firmware binaries and update files as GitHub Actions artifacts

## Testing
- `yamllint .github/workflows/build.yml` *(fails: command not found)*
- `sudo apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is no longer signed.)*


------
https://chatgpt.com/codex/tasks/task_e_689a346518288323b4a8ee9b45c98342